### PR TITLE
Disable ephemeral responses by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ DB_PATH=/var/lib/pii_bot/planets.db /opt/pii_bot/.venv/bin/python PII_BOT.py
 | `DB_PATH` | Путь к файлу базы данных SQLite | `planets.db` |
 | `LOG_DIR` | Каталог для файлов логов | `logs` |
 | `LOG_LEVEL` | Уровень логирования (`DEBUG`, `INFO`, …) | `INFO` |
+| `ALLOW_EPHEMERAL_RESPONSES` | Включить ли ответы, видимые только вызывающему | `false` |
 | `PII_BOT_TOKEN_ENV` | Имя переменной с токеном Discord | `DISCORD_TOKEN` |
 | `DEFAULT_SLOTS` | Слоты планет для POS по умолчанию | `10` |
 | `DEFAULT_DRILLS` | Количество буров на планету по умолчанию | `22` |
@@ -59,7 +60,7 @@ DB_PATH=/var/lib/pii_bot/planets.db /opt/pii_bot/.venv/bin/python PII_BOT.py
 
 ### Настройки `/posdefaults`
 
-Позволяют хранить значения по умолчанию для команд, связанных с POS. Все ответы приходят личным сообщением (ephemeral).
+Позволяют хранить значения по умолчанию для команд, связанных с POS. По умолчанию ответы видны всем, но приватный режим можно вернуть, установив `ALLOW_EPHEMERAL_RESPONSES=true`.
 
 - `/posdefaults setguild slots:<число> drills:<число>` — задаёт стандартные значения слотов и буров для всего сервера. Требуются права администратора.
 - `/posdefaults set slots:<число> drills:<число>` — сохраняет личные значения пользователя для текущего сервера.


### PR DESCRIPTION
## Summary
- add a helper that centralizes whether bot replies should be ephemeral and disable ephemeral replies unless ALLOW_EPHEMERAL_RESPONSES is enabled
- update command handlers to route all ephemeral responses through the helper so replies default to public visibility
- document the new environment variable and the changed default behaviour in the README

## Testing
- python -m compileall PII_BOT.py

------
https://chatgpt.com/codex/tasks/task_e_68e0da1b818483209d73719c52922723